### PR TITLE
Add support for multiple security schemes in AND fashion

### DIFF
--- a/connexion/operations/secure.py
+++ b/connexion/operations/secure.py
@@ -76,72 +76,84 @@ class SecureOperation(object):
             if not security_req:
                 auth_funcs.append(self._api.security_handler_factory.verify_none())
                 continue
-            elif len(security_req) > 1:
-                logger.warning("... More than one security scheme in security requirement defined. "
-                               "**DENYING ALL REQUESTS**", extra=vars(self))
-                return self._api.security_handler_factory.security_deny
 
-            scheme_name, scopes = next(iter(security_req.items()))
-            security_scheme = self.security_schemes[scheme_name]
+            sec_req_funcs = {}
+            oauth = False
+            for scheme_name, scopes in security_req.items():
+                security_scheme = self.security_schemes[scheme_name]
 
-            if security_scheme['type'] == 'oauth2':
-                required_scopes = scopes
-                token_info_func = self._api.security_handler_factory.get_tokeninfo_func(security_scheme)
-                scope_validate_func = self._api.security_handler_factory.get_scope_validate_func(security_scheme)
-                if not token_info_func:
-                    logger.warning("... x-tokenInfoFunc missing", extra=vars(self))
-                    continue
+                if security_scheme['type'] == 'oauth2':
+                    if oauth:
+                        logger.warning("... multiple OAuth2 security schemes in AND fashion not supported", extra=vars(self))
+                        break
+                    oauth = True
+                    required_scopes = scopes
+                    token_info_func = self._api.security_handler_factory.get_tokeninfo_func(security_scheme)
+                    scope_validate_func = self._api.security_handler_factory.get_scope_validate_func(security_scheme)
+                    if not token_info_func:
+                        logger.warning("... x-tokenInfoFunc missing", extra=vars(self))
+                        break
 
-                auth_funcs.append(self._api.security_handler_factory.verify_oauth(token_info_func, scope_validate_func))
+                    sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_oauth(
+                        token_info_func, scope_validate_func)
 
-            # Swagger 2.0
-            elif security_scheme['type'] == 'basic':
-                basic_info_func = self._api.security_handler_factory.get_basicinfo_func(security_scheme)
-                if not basic_info_func:
-                    logger.warning("... x-basicInfoFunc missing", extra=vars(self))
-                    continue
-
-                auth_funcs.append(self._api.security_handler_factory.verify_basic(basic_info_func))
-
-            # OpenAPI 3.0.0
-            elif security_scheme['type'] == 'http':
-                scheme = security_scheme['scheme'].lower()
-                if scheme == 'basic':
+                # Swagger 2.0
+                elif security_scheme['type'] == 'basic':
                     basic_info_func = self._api.security_handler_factory.get_basicinfo_func(security_scheme)
                     if not basic_info_func:
                         logger.warning("... x-basicInfoFunc missing", extra=vars(self))
-                        continue
+                        break
 
-                    auth_funcs.append(self._api.security_handler_factory.verify_basic(basic_info_func))
-                elif scheme == 'bearer':
-                    bearer_info_func = self._api.security_handler_factory.get_bearerinfo_func(security_scheme)
-                    if not bearer_info_func:
-                        logger.warning("... x-bearerInfoFunc missing", extra=vars(self))
-                        continue
-                    auth_funcs.append(self._api.security_handler_factory.verify_bearer(bearer_info_func))
+                    sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_basic(basic_info_func)
+
+                # OpenAPI 3.0.0
+                elif security_scheme['type'] == 'http':
+                    scheme = security_scheme['scheme'].lower()
+                    if scheme == 'basic':
+                        basic_info_func = self._api.security_handler_factory.get_basicinfo_func(security_scheme)
+                        if not basic_info_func:
+                            logger.warning("... x-basicInfoFunc missing", extra=vars(self))
+                            break
+
+                        sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_basic(basic_info_func)
+                    elif scheme == 'bearer':
+                        bearer_info_func = self._api.security_handler_factory.get_bearerinfo_func(security_scheme)
+                        if not bearer_info_func:
+                            logger.warning("... x-bearerInfoFunc missing", extra=vars(self))
+                            break
+                        sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_bearer(bearer_info_func)
+                    else:
+                        logger.warning("... Unsupported http authorization scheme %s" % scheme, extra=vars(self))
+                        break
+
+                elif security_scheme['type'] == 'apiKey':
+                    scheme = security_scheme.get('x-authentication-scheme', '').lower()
+                    if scheme == 'bearer':
+                        bearer_info_func = self._api.security_handler_factory.get_bearerinfo_func(security_scheme)
+                        if not bearer_info_func:
+                            logger.warning("... x-bearerInfoFunc missing", extra=vars(self))
+                            break
+                        sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_bearer(bearer_info_func)
+                    else:
+                        apikey_info_func = self._api.security_handler_factory.get_apikeyinfo_func(security_scheme)
+                        if not apikey_info_func:
+                            logger.warning("... x-apikeyInfoFunc missing", extra=vars(self))
+                            break
+
+                        sec_req_funcs[scheme_name] = self._api.security_handler_factory.verify_api_key(
+                            apikey_info_func, security_scheme['in'], security_scheme['name']
+                        )
+
                 else:
-                    logger.warning("... Unsupported http authorization scheme %s" % scheme, extra=vars(self))
-
-            elif security_scheme['type'] == 'apiKey':
-                scheme = security_scheme.get('x-authentication-scheme', '').lower()
-                if scheme == 'bearer':
-                    bearer_info_func = self._api.security_handler_factory.get_bearerinfo_func(security_scheme)
-                    if not bearer_info_func:
-                        logger.warning("... x-bearerInfoFunc missing", extra=vars(self))
-                        continue
-                    auth_funcs.append(self._api.security_handler_factory.verify_bearer(bearer_info_func))
-                else:
-                    apikey_info_func = self._api.security_handler_factory.get_apikeyinfo_func(security_scheme)
-                    if not apikey_info_func:
-                        logger.warning("... x-apikeyInfoFunc missing", extra=vars(self))
-                        continue
-
-                    auth_funcs.append(self._api.security_handler_factory.verify_api_key(
-                        apikey_info_func, security_scheme['in'], security_scheme['name']
-                        ))
-
+                    logger.warning("... Unsupported security scheme type %s" % security_scheme['type'], extra=vars(self))
+                    break
             else:
-                logger.warning("... Unsupported security scheme type %s" % security_scheme['type'], extra=vars(self))
+                # No break encountered: no missing funcs
+                if len(sec_req_funcs) == 1:
+                    (func,) = sec_req_funcs.values()
+                    auth_funcs.append(func)
+                else:
+                    auth_funcs.append(self._api.security_handler_factory.verify_multiple_schemes(sec_req_funcs))
 
         return functools.partial(self._api.security_handler_factory.verify_security, auth_funcs, required_scopes)
 

--- a/connexion/security/security_handler_factory.py
+++ b/connexion/security/security_handler_factory.py
@@ -267,6 +267,28 @@ class AbstractSecurityHandlerFactory(abc.ABC):
 
         return wrapper
 
+    def verify_multiple_schemes(self, schemes):
+        """
+        Verifies multiple authentication schemes in AND fashion.
+        If any scheme fails, the entire authentication fails.
+
+        :param schemes: mapping scheme_name to auth function
+        :type schemes: dict
+        :rtype: types.FunctionType
+        """
+
+        def wrapper(request, required_scopes):
+            token_info = {}
+            for scheme_name, func in schemes.items():
+                result = func(request, required_scopes)
+                if result is self.no_value:
+                    return self.no_value
+                token_info[scheme_name] = result
+
+            return token_info
+
+        return wrapper
+
     @staticmethod
     def verify_none():
         """

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -87,6 +87,19 @@ semantics as for ``x-tokenInfoFunc``, but the function accepts one parameter: to
 
 You can find a `minimal JWT example application`_ in Connexion's "examples/openapi3" folder.
 
+Multiple Authentication Schemes
+-------------------------------
+
+With Connexion, it is also possible to combine multiple authentication schemes
+as described in the `OpenAPI specification`_. When multiple authentication
+schemes are combined using logical AND, the ``token_info`` argument will
+consist of a dictionary mapping the names of the security scheme to their
+corresponding ``token_info``.
+
+Multiple OAuth2 security schemes in AND fashion are not supported.
+
+.. _OpenAPI specification: https://swagger.io/docs/specification/authentication/#multiple
+
 Deploying Authentication
 ------------------------
 


### PR DESCRIPTION
Add support for combining [multiple authentication schemes in AND fashion](https://swagger.io/docs/specification/authentication/#multiple). The `token_info` and `user` argument will differ as a dict mapping security scheme names to token info results for that scheme is now returned as `token_info`.

Multiple OAuth2 authentication schemes in AND fashion is not supported.