### PR TITLE
Trigger github actions on merge to master

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,9 @@
 name: CI/CD pipeline
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,6 @@ Connexion
    :alt: Build status
    :target: https://github.com/ml6team/connexion/actions/workflows/pipeline.yml
 
-.. image:: https://travis-ci.org/zalando/connexion.svg?branch=master
-   :target: https://travis-ci.org/zalando/connexion
-   :alt: Travis CI build status
-
 .. image:: https://coveralls.io/repos/zalando/connexion/badge.svg?branch=master
    :target: https://coveralls.io/r/ml6team/connexion?branch=master
    :alt: Coveralls status


### PR DESCRIPTION
This PR adds a trigger to the github actions to run on pushes to master.

I've also removed the leftover Travis CI Build status badge from the README as @svetlana-v pointed out in #2.
